### PR TITLE
Feature/split main window refactor

### DIFF
--- a/src/MyBudget.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/MyBudget.UI/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MyBudget.UI.Views;
 using System.Threading.Tasks;
@@ -13,6 +14,17 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         parentWindow = parent;
     }
+
+    public MainWindowViewModel()
+    {
+        
+    }
+
+    [ObservableProperty]
+    private bool isPaneOpen = true;
+
+    [RelayCommand]
+    private void TogglePane() => IsPaneOpen ^= true;
 
     [RelayCommand]
     private async Task OpenExpenseEditor()

--- a/src/MyBudget.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/MyBudget.UI/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MyBudget.UI.Views;
@@ -13,15 +14,19 @@ public partial class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel(Window parent)
     {
         parentWindow = parent;
+        ActiveView = new ExpenseEditorRootView();
     }
 
     public MainWindowViewModel()
     {
-        
+        ActiveView = new ExpenseEditorRootView();
     }
 
     [ObservableProperty]
     private bool isPaneOpen = true;
+
+    [ObservableProperty]
+    private Visual activeView;
 
     [RelayCommand]
     private void TogglePane() => IsPaneOpen ^= true;

--- a/src/MyBudget.UI/ViewModels/MainWindowViewModel.cs
+++ b/src/MyBudget.UI/ViewModels/MainWindowViewModel.cs
@@ -23,7 +23,7 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     [ObservableProperty]
-    private bool isPaneOpen = true;
+    private bool isPaneOpen;
 
     [ObservableProperty]
     private Visual activeView;

--- a/src/MyBudget.UI/Views/ExpenseEditorRootView.axaml
+++ b/src/MyBudget.UI/Views/ExpenseEditorRootView.axaml
@@ -1,0 +1,30 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             xmlns:views="using:MyBudget.UI.Views"
+             x:Class="MyBudget.UI.Views.ExpenseEditorRootView">
+  <Grid ColumnDefinitions="Auto, Auto, *, Auto, Auto">
+    <views:ExpenseEditorView Grid.Column="0"/>
+
+    <Rectangle Grid.Column="1"
+               VerticalAlignment="Stretch"
+               Width="1"
+               Margin="5, 20"
+               Fill="Gray"/>
+
+    <views:ExpenseListView Grid.Column="2"/>
+
+    <Rectangle Grid.Column="3"
+               VerticalAlignment="Stretch"
+               Width="1"
+               Margin="5, 20"
+               Fill="Gray"/>
+
+    <Grid Grid.Column="4" RowDefinitions="Auto, *">
+      <views:CategoryEditorView Grid.Row="0"/>
+      <views:CategoryListView Grid.Row="1"/>
+    </Grid>
+  </Grid>
+</UserControl>

--- a/src/MyBudget.UI/Views/ExpenseEditorRootView.axaml.cs
+++ b/src/MyBudget.UI/Views/ExpenseEditorRootView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace MyBudget.UI.Views
+{
+    public partial class ExpenseEditorRootView : UserControl
+    {
+        public ExpenseEditorRootView()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/MyBudget.UI/Views/ExpenseEditorView.axaml
+++ b/src/MyBudget.UI/Views/ExpenseEditorView.axaml
@@ -8,6 +8,11 @@
              x:Class="MyBudget.UI.Views.ExpenseEditorView"
              x:DataType="vm:ExpenseEditorViewModel"
              MinWidth="380">
+
+  <UserControl.DataContext>
+    <vm:ExpenseEditorViewModel />
+  </UserControl.DataContext>
+  
   <DockPanel Margin="15">
     <DockPanel DockPanel.Dock="Top"
                Margin="0 0 0 10">

--- a/src/MyBudget.UI/Views/MainWindow.axaml
+++ b/src/MyBudget.UI/Views/MainWindow.axaml
@@ -24,7 +24,10 @@
               Margin="7"
               Name="menuButton"
               Command="{Binding TogglePaneCommand}">
-        <icons:MaterialIcon Width="25" Height="25" Kind="Menu" />
+        <StackPanel Orientation="Horizontal" Spacing="5">
+          <icons:MaterialIcon Width="25" Height="25" Kind="Menu" />
+          <TextBlock VerticalAlignment="Center" Text="Menu" />
+        </StackPanel>
       </Button>
       <TextBlock VerticalAlignment="Center"
                  Classes="theme-text-heading"

--- a/src/MyBudget.UI/Views/MainWindow.axaml
+++ b/src/MyBudget.UI/Views/MainWindow.axaml
@@ -37,7 +37,7 @@
     </StackPanel>
     <SplitView DisplayMode="Overlay"
                IsPaneOpen="{Binding IsPaneOpen}"
-               OpenPaneLength="200"
+               OpenPaneLength="250"
                Content="{Binding ActiveView}"
                UseLightDismissOverlayMode="True">
       <SplitView.Pane>

--- a/src/MyBudget.UI/Views/MainWindow.axaml
+++ b/src/MyBudget.UI/Views/MainWindow.axaml
@@ -1,27 +1,36 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:vm="using:MyBudget.UI.ViewModels"
         xmlns:actipro="http://schemas.actiprosoftware.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:MyBudget.UI.ViewModels"
         xmlns:views="using:MyBudget.UI.Views"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
+        mc:Ignorable="d" d:DesignWidth="1500" d:DesignHeight="450"
         x:Class="MyBudget.UI.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/avalonia-logo.ico"
         Title="MyBudget.UI">
 
     <Design.DataContext>
-        <!-- This only sets the DataContext for the previewer in an IDE,
-             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-        <vm:MainWindowViewModel/>
+      <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-  <!--<Button Content="Open expense editor" Command="{Binding OpenExpenseEditorCommand}"/>-->
   <DockPanel>
-    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
-      <Button Command="{Binding TogglePaneCommand}">Menu</Button>
-      <TextBlock HorizontalAlignment="Center" Text="My Budget" />
+    <StackPanel DockPanel.Dock="Top" 
+                Orientation="Horizontal"
+                Background="{actipro:ThemeResource ControlBackgroundBrushSolidAccent}">
+      <Button Classes="theme-soft accent"
+              Margin="7"
+              Name="menuButton"
+              Command="{Binding TogglePaneCommand}">
+        <icons:MaterialIcon Width="25" Height="25" Kind="Menu" />
+      </Button>
+      <TextBlock VerticalAlignment="Center"
+                 Classes="theme-text-heading"
+                 Foreground="{actipro:ThemeResource ControlForegroundBrushSolidAccent}"
+                 Margin="10 0"
+                 Text="My Budget" />
     </StackPanel>
     <SplitView DisplayMode="Overlay"
                IsPaneOpen="{Binding IsPaneOpen}"

--- a/src/MyBudget.UI/Views/MainWindow.axaml
+++ b/src/MyBudget.UI/Views/MainWindow.axaml
@@ -23,13 +23,10 @@
       <Button Command="{Binding TogglePaneCommand}">Menu</Button>
       <TextBlock HorizontalAlignment="Center" Text="My Budget" />
     </StackPanel>
-    <SplitView Background="AliceBlue" DisplayMode="Inline" IsPaneOpen="{Binding IsPaneOpen}" OpenPaneLength="200" >
+    <SplitView DisplayMode="Inline" IsPaneOpen="{Binding IsPaneOpen}" OpenPaneLength="200" Content="{Binding ActiveView}">
       <SplitView.Pane>
         <views:NavigationView />
       </SplitView.Pane>
-      <TextBlock Classes="theme-text-heading size-xl accent">
-        A Lot of really cool text can go right in here and let's see what happens
-      </TextBlock>
     </SplitView>
   </DockPanel>
 

--- a/src/MyBudget.UI/Views/MainWindow.axaml
+++ b/src/MyBudget.UI/Views/MainWindow.axaml
@@ -1,8 +1,10 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:MyBudget.UI.ViewModels"
+        xmlns:actipro="http://schemas.actiprosoftware.com/avaloniaui"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:views="using:MyBudget.UI.Views"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="MyBudget.UI.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
@@ -15,6 +17,20 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-  <Button Content="Open expense editor" Command="{Binding OpenExpenseEditorCommand}"/>
+  <!--<Button Content="Open expense editor" Command="{Binding OpenExpenseEditorCommand}"/>-->
+  <DockPanel>
+    <StackPanel DockPanel.Dock="Top" Orientation="Horizontal">
+      <Button Command="{Binding TogglePaneCommand}">Menu</Button>
+      <TextBlock HorizontalAlignment="Center" Text="My Budget" />
+    </StackPanel>
+    <SplitView Background="AliceBlue" DisplayMode="Inline" IsPaneOpen="{Binding IsPaneOpen}" OpenPaneLength="200" >
+      <SplitView.Pane>
+        <views:NavigationView />
+      </SplitView.Pane>
+      <TextBlock Classes="theme-text-heading size-xl accent">
+        A Lot of really cool text can go right in here and let's see what happens
+      </TextBlock>
+    </SplitView>
+  </DockPanel>
 
 </Window>

--- a/src/MyBudget.UI/Views/MainWindow.axaml
+++ b/src/MyBudget.UI/Views/MainWindow.axaml
@@ -23,7 +23,11 @@
       <Button Command="{Binding TogglePaneCommand}">Menu</Button>
       <TextBlock HorizontalAlignment="Center" Text="My Budget" />
     </StackPanel>
-    <SplitView DisplayMode="Inline" IsPaneOpen="{Binding IsPaneOpen}" OpenPaneLength="200" Content="{Binding ActiveView}">
+    <SplitView DisplayMode="Overlay"
+               IsPaneOpen="{Binding IsPaneOpen}"
+               OpenPaneLength="200"
+               Content="{Binding ActiveView}"
+               UseLightDismissOverlayMode="True">
       <SplitView.Pane>
         <views:NavigationView />
       </SplitView.Pane>

--- a/src/MyBudget.UI/Views/NavigationView.axaml
+++ b/src/MyBudget.UI/Views/NavigationView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="MyBudget.UI.Views.NavigationView">
+  <StackPanel Orientation="Vertical" Spacing="10">
+    <TextBlock Classes="theme-text-body size-xl accent" Text="Home" />
+    <TextBlock Classes="theme-text-body size-xl accent" Text="Expenses" />
+  </StackPanel>
+</UserControl>

--- a/src/MyBudget.UI/Views/NavigationView.axaml
+++ b/src/MyBudget.UI/Views/NavigationView.axaml
@@ -2,10 +2,28 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:actipro="http://schemas.actiprosoftware.com/avaloniaui"
+             xmlns:icons="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="MyBudget.UI.Views.NavigationView">
-  <StackPanel Orientation="Vertical" Spacing="10">
-    <TextBlock Classes="theme-text-body size-xl accent" Text="Home" />
-    <TextBlock Classes="theme-text-body size-xl accent" Text="Expenses" />
+  <StackPanel Orientation="Vertical" Spacing="15">
+    <Border />
+    <Button HorizontalContentAlignment="Left" Classes="theme-link">
+      <StackPanel Orientation="Horizontal" Spacing="10">
+        <icons:MaterialIcon Width="30" Height="30" Kind="HomeAnalytics" />
+        <TextBlock Classes="theme-text-body size-xl" Text="Home" />
+      </StackPanel>
+    </Button>
+    <Button HorizontalContentAlignment="Left" Classes="theme-link">
+      <StackPanel Orientation="Horizontal" Spacing="10">
+        <icons:MaterialIcon Width="30" Height="30" Kind="CurrencyUsd" />
+        <TextBlock Classes="theme-text-body size-xl" Text="Expenses" />
+      </StackPanel>
+    </Button>
   </StackPanel>
+  <UserControl.Styles>
+    <Style Selector="StackPanel > Button > StackPanel">
+      <Setter Property="Margin" Value="15 0 0 0" />
+    </Style>
+  </UserControl.Styles>
 </UserControl>

--- a/src/MyBudget.UI/Views/NavigationView.axaml.cs
+++ b/src/MyBudget.UI/Views/NavigationView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace MyBudget.UI.Views
+{
+    public partial class NavigationView : UserControl
+    {
+        public NavigationView()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
- Added in `SplitView` control
- Added buttons that will eventually control swapping views
- Added menu button that will pop out the `SplitView`
- Added property to control which "root view" serves as the `SplitPane` content view
- Moved expense editor view as the default view while the home view is being worked on